### PR TITLE
Fix: Logout Button Not Working in Billing Section

### DIFF
--- a/billing.py
+++ b/billing.py
@@ -22,7 +22,7 @@ class billClass:
         self.icon_title=PhotoImage(file="images/logo1.png")
         title=Label(self.root,text="Inventory Administration System",image=self.icon_title,compound=LEFT, font=("times new roman",40,"bold"),bg="#010c48",fg="white",anchor="w",padx=20).place(x=0,y=0,relwidth=1,height=70)
         
-        btn_logout=Button(self.root,text="Logout",font=("times new roman",15,"bold"),bg="yellow", cursor="hand2").place(x=1150,y=10,height=50,width=150)
+        btn_logout=Button(self.root,text="Logout",command=self.Login1,font=("times new roman",15,"bold"),bg="yellow", cursor="hand2").place(x=1150,y=10,height=50,width=150)
         self.lbl_clock=Label(self.root,text="Welcome to Inventory Administration System\t\t Date: DD-MM-YYYY\t\t Time: HH:MM:SS", font=("times new roman",15),bg="#4d636d",fg="white")
         self.lbl_clock.place(x=0,y=70,relwidth=1,height=30)
 
@@ -490,6 +490,9 @@ class billClass:
         else:
             messagebox.showerror("Error","Please generate bill,to print the receipt",parent=self.root)
             
+    def Login1(self):
+        self.root.destroy()
+        os.system("python Login.py")
 
 if __name__=="__main__":
 


### PR DESCRIPTION
This pull request resolves Issue #3: Logout Button Not Working in Billing Section.
The issue was due to an incorrect event listener for the Logout button. Updated the button logic to properly handle the logout process and redirect the user to the login page.
